### PR TITLE
correct doc string where THM bi should be bf 🐱‍👤

### DIFF
--- a/petbox/dca/primary.py
+++ b/petbox/dca/primary.py
@@ -364,13 +364,13 @@ class THM(MultisegmentHyperbolic):
             transient linear flow.
             See literature for more details.
 
-        bi: float
+        bf: float
             The final hyperbolic parameter after transition. Represents the boundary-dominated or
             boundary-influenced flow regime.
 
         telf: float
             The time to end of linear flow in units of ``day``, or more specifically the time at
-            which ``b(t) < bi``. Visual end of half slope occurs ``~2.5x`` after ``telf``.
+            which ``b(t) < bf``. Visual end of half slope occurs ``~2.5x`` after ``telf``.
 
         bterm: Optional[float] = None
             The terminal value of the hyperbolic parameter. Has two interpretations:

--- a/petbox/dca/primary.py
+++ b/petbox/dca/primary.py
@@ -370,7 +370,7 @@ class THM(MultisegmentHyperbolic):
 
         telf: float
             The time to end of linear flow in units of ``day``, or more specifically the time at
-            which ``b(t) < bf``. Visual end of half slope occurs ``~2.5x`` after ``telf``.
+            which ``b(t) < bi``. Visual end of half slope occurs ``~2.5x`` after ``telf``.
 
         bterm: Optional[float] = None
             The terminal value of the hyperbolic parameter. Has two interpretations:


### PR DESCRIPTION
I am working through the modules and noticed what looks like a simple documentation error to me in the doc string for the Transient Hyperbolic Model. The documentation is great and I really appreciate it!