### PR TITLE
chore: post-merge hardening, coverage, and 2.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,10 @@ jobs:
       run: pip install -e ".[dev]"
     - name: Run tests
       run: pytest
+    - name: Upload coverage to Coveralls
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+      uses: coverallsapp/github-action@v2
+      continue-on-error: true
+      with:
+        file: coverage.lcov
+        format: lcov

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.lcov
 *.cover
 .hypothesis/
 .pytest_cache/

--- a/docs/integration_validation.py
+++ b/docs/integration_validation.py
@@ -88,6 +88,23 @@ def print_table(models, t):
         print(f'{label:<55} {rel_err.max():>15.4e} {rel_err.mean():>16.4e}')
 
 
+def print_ngrid_convergence(ple_cases, t):
+    """Print worst-case (over the PLE cases) relative error vs n_grid, showing
+    the second-order convergence of the log-spaced trapezoid rule."""
+    grids = [250, 500, 1000, 2000, 5000, 10_000, 20_000]
+    refs = [reference_cum(m._qfn, t) for _, m in ple_cases]
+    print(f'\n{"n_grid":>8} {"Worst Max Rel Err (%)":>22} {"Worst Mean Rel Err (%)":>24}')
+    print('-' * 56)
+    for ng in grids:
+        max_e = mean_e = 0.0
+        for (_, m), ref in zip(ple_cases, refs):
+            mask = ref > 0
+            rel = np.abs((m.cum(t, n_grid=ng)[mask] - ref[mask]) / ref[mask]) * 100
+            max_e = max(max_e, rel.max())
+            mean_e = max(mean_e, rel.mean())
+        print(f'{ng:>8d} {max_e:>22.2e} {mean_e:>24.2e}')
+
+
 def main() -> None:
     t = dca.get_time(start=1.0, end=10_000.0, n=101)
 
@@ -115,6 +132,7 @@ def main() -> None:
                 'docs/img/integration_accuracy.png',
                 'Primary Phase: PLE Cumulative Volume Accuracy')
     print_table(ple_models, t)
+    print_ngrid_convergence(ple_cases, t)
 
     # ----------------------------------------------------------------
     # Associated phase: PLYield on MH primary

--- a/docs/numerical_integration.rst
+++ b/docs/numerical_integration.rst
@@ -11,8 +11,12 @@ function :math:`q(t)`:
     N(t) = \int_0^t q(\tau) \, d\tau
 
 Models with closed-form cumulative solutions (MH, THM, SE, Duong) do
-not use numerical integration. The Power-Law Exponential (PLE) model
-and associated phase models (PLYield) use the method described here.
+not use numerical integration, with one exception: the Stretched
+Exponential (SE) closed form carries a :math:`\Gamma(1/n)` coefficient
+that overflows for very small :math:`n` (:math:`n \lesssim 0.006`), where
+SE falls back to the numerical method described here. The Power-Law
+Exponential (PLE) model and associated phase models (PLYield) always use
+this method.
 
 
 Method
@@ -71,6 +75,35 @@ from 1 to 10,000 days. Reference computed with adaptive quadrature
 The worst-case maximum relative error is **0.00022%** (2.2 parts per
 million), which is well below the uncertainty inherent in empirical
 decline curve parameters. Mean errors are an order of magnitude smaller.
+
+The grid size is configurable via the ``n_grid`` keyword, which flows
+through ``cum(t, n_grid=...)`` (and the other volume methods). The
+log-spaced trapezoid rule converges at second order --- each doubling of
+``n_grid`` cuts the relative error roughly four-fold --- so the knob
+trades accuracy for a proportional reduction in grid work. Worst-case
+error over the four PLE cases above:
+
+.. csv-table::
+   :header: "n_grid", "Max Rel Err (%)", "Mean Rel Err (%)"
+   :widths: 12, 20, 20
+
+   "250",     "0.11",     "0.087"
+   "500",     "0.056",    "0.044"
+   "1,000",   "0.019",    "0.014"
+   "2,000",   "0.0054",   "0.0041"
+   "5,000",   "0.00087",  "0.00068"
+   "10,000",  "0.00022",  "0.00017"
+   "20,000",  "0.000056", "0.000044"
+
+The default of 10,000 (:math:`\sim 2 \times 10^{-6}` relative error) is
+unchanged. A smaller value such as 2,000 (:math:`\sim 5 \times 10^{-5}`)
+remains far below the noise in empirical production data, and is a
+reasonable choice when integrating repeatedly at moderate accuracy (e.g.
+fitting on a fixed ``t``). ``n_grid`` must be :math:`\ge 2`; smaller
+values raise ``ValueError``. For typical evaluation arrays the accuracy
+is governed by ``n_grid`` rather than by the density of the requested
+``t`` values --- the log-spaced grid dominates the merged integration
+grid, so refining ``t`` alone does not improve accuracy.
 
 .. figure:: img/integration_accuracy.png
    :width: 100%

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -6,6 +6,37 @@ Version History
    :noindex:
 
 
+2.1.0
+-----
+
+* Bug Fix
+    * **Breaking numerical change:** Fix missing ``gamma(1/n)`` factor in the Stretched
+      Exponential (``SE``) closed-form cumulative and EUR. ``SE._Nfn`` returned
+      ``qi*tau/n * P(1/n, (t/tau)^n)`` using the *regularised* lower incomplete gamma
+      (scipy ``gammainc`` = P), but the integral of ``qi*exp(-(t/tau)^n)`` is
+      ``qi*tau/n * gamma(1/n) * P(1/n, (t/tau)^n)``. Cumulative volume and EUR were
+      wrong by a factor of ``gamma(1/n)`` for any ``n != 0.5`` --- understated up to
+      ~64% at ``n=0.3``, exact at ``n=0.5``, overstated ~10% for ``n > 0.5``. Any SE
+      forecast with ``n != 0.5`` will now report different cumulative/EUR values.
+      For very small ``n``, ``gamma(1/n)`` overflows (the closed-form EUR genuinely
+      diverges there); SE now falls back to the bounded numerical integrator.
+
+* Performance
+    * Expose ``n_grid`` in the numerical integrator via ``cum(t, n_grid=...)`` (and the
+      other volume methods). Default 10,000 is unchanged; a smaller value (e.g. 2,000,
+      ~5e-5 relative error) trades accuracy for a proportional speed-up on the
+      numerically-integrated path (PLE, associated yields). ``n_grid < 2`` raises
+      ``ValueError``.
+
+* Other changes
+    * Remove unreachable ``pass`` (and commented-out lines) after a ``raise`` in
+      ``THM._validate``; flagged as unreachable by ``mypy``. No behaviour change.
+    * Add ``test_SE_cum_matches_integral`` and ``test_PLE_cum_matches_integral``,
+      which compare ``cum`` against adaptive quadrature of the rate --- the previous
+      ``check_model`` assertions only verified finiteness, so a constant-factor error
+      in a closed-form cumulative passed silently.
+
+
 2.0.0
 -----
 

--- a/petbox/dca/base.py
+++ b/petbox/dca/base.py
@@ -140,8 +140,12 @@ class DeclineCurve(ABC):
             t: Union[float, numpy.NDFloat]
                 An array of times at which to evaluate the function.
 
-            **kwargs
-                Additional keyword arguments (currently unused, reserved for future use).
+            n_grid: int
+                For models evaluated by numerical integration (PLE, associated-phase
+                yields, and SE at very small ``n``), the number of log-spaced grid
+                points used. Defaults to 10,000 (~1e-6 relative accuracy); must be
+                ``>= 2``. A smaller value (e.g. 2,000, ~5e-5) trades accuracy for
+                speed. Ignored by models with a closed-form cumulative.
 
         Returns
         -------
@@ -170,8 +174,9 @@ class DeclineCurve(ABC):
                 A start time of the first interval. If not given, the first element
                 of ``t`` is used.
 
-            **kwargs
-                Additional keyword arguments (currently unused, reserved for future use).
+            n_grid: int
+                Number of log-spaced integration points, for models evaluated by
+                numerical integration; see :meth:`cum`. Must be ``>= 2``.
 
         Returns
         -------
@@ -197,8 +202,9 @@ class DeclineCurve(ABC):
             t: Union[float, numpy.NDFloat]
                 An array of interval end times at which to evaluate the function.
 
-            **kwargs
-                Additional keyword arguments (currently unused, reserved for future use).
+            n_grid: int
+                Number of log-spaced integration points, for models evaluated by
+                numerical integration; see :meth:`cum`. Must be ``>= 2``.
 
         Returns
         -------
@@ -226,8 +232,9 @@ class DeclineCurve(ABC):
             t0: Optional[Union[float, numpy.NDFloat]]
                 A start time of the first interval. If not given, assumed to be zero.
 
-            **kwargs
-                Additional keyword arguments (currently unused, reserved for future use).
+            n_grid: int
+                Number of log-spaced integration points, for models evaluated by
+                numerical integration; see :meth:`cum`. Must be ``>= 2``.
 
         Returns
         -------
@@ -235,7 +242,7 @@ class DeclineCurve(ABC):
         """
         t = self._validate_ndarray(t)
         t0 = np.atleast_1d(0.0).astype(np.float64)
-        return (np.diff(self._Nfn(t, **kwargs), prepend=self._Nfn(t0))  # type: ignore
+        return (np.diff(self._Nfn(t, **kwargs), prepend=self._Nfn(t0, **kwargs))  # type: ignore
                 / np.diff(t, prepend=t0) * DAYS_PER_MONTH)  # type: ignore
 
     def D(self, t: Union[float, NDFloat]) -> NDFloat:
@@ -445,17 +452,21 @@ class DeclineCurve(ABC):
                 ~1e-6 relative accuracy; the whole grid is rebuilt on every call, so
                 callers integrating repeatedly at moderate accuracy (e.g. fitting on
                 the same ``t``) can pass a smaller value: ~2,000 holds ~5e-5, well
-                below production-data noise, for a proportional speed-up. Flows through
+                below production-data noise, for a proportional speed-up. Must be
+                ``>= 2``; a smaller value raises ``ValueError``. Flows through
                 ``cum(t, n_grid=...)``.
 
         Returns
         -------
             cumulative integral: NDFloat
         """
+        n_grid = int(kwargs.get('n_grid', 10_000))
+        if n_grid < 2:
+            raise ValueError(f'n_grid must be >= 2, got {n_grid}')
+
         if len(t) == 0:
             return np.array([], dtype=np.float64)
 
-        n_grid = int(kwargs.get('n_grid', 10_000))
         eps = 1e-12
         t_max = float(t[-1]) if t[-1] > 0 else 1.0
         log_grid = np.logspace(np.log10(eps), np.log10(t_max), n_grid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "petbox-dca"
-version = "2.0.0"
+version = "2.1.0"
 description = "Decline Curve Library"
 readme = {file = "README.rst", content-type = "text/x-rst"}
 license = "MIT"
@@ -113,7 +113,7 @@ warn_unused_configs = true
 plugins = ["numpy.typing.mypy_plugin"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=petbox.dca --cov-report=term-missing --cov-config=pyproject.toml --hypothesis-show-statistics -v test"
+addopts = "--cov=petbox.dca --cov-report=term-missing --cov-report=lcov:coverage.lcov --cov-config=pyproject.toml --hypothesis-show-statistics -v test"
 
 [tool.coverage.run]
 # branch = true

--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -23,6 +23,19 @@ def test_SE_cum_matches_integral(n: float) -> None:
     assert np.allclose(se.cum(t), ref, rtol=1e-4)
 
 
+@pytest.mark.parametrize('n', [0.005, 0.003])
+def test_SE_cum_small_n_fallback(n: float) -> None:
+    """For very small n, gamma(1/n) overflows and SE.cum falls back to the
+    numerical integrator; the result must still match the integral of the rate."""
+    qi, tau = 1000.0, 30.0
+    se = dca.SE(qi, tau, n)
+    t = dca.get_time(1.0, 5000.0, 40)
+    cum = se.cum(t)
+    assert np.all(np.isfinite(cum))
+    ref = _quad_cum(lambda s: qi * np.exp(-(s / tau) ** n), t)
+    assert np.allclose(cum, ref, rtol=1e-4)
+
+
 def test_integrate_with_PLE_accuracy() -> None:
     """Verify _integrate_with produces correct cumulative volumes for PLE."""
     ple = dca.PLE(qi=1000.0, Di=0.01, Dinf=0.0001, n=0.5)
@@ -115,3 +128,13 @@ def test_integrate_with_n_grid_parameter() -> None:
     coarse = ple.cum(t, n_grid=2000)
     fine = ple.cum(t, n_grid=10_000)
     assert np.allclose(coarse, fine, rtol=1e-3)
+
+
+@pytest.mark.parametrize('n_grid', [1, 0, -5])
+def test_integrate_with_n_grid_too_small_raises(n_grid: int) -> None:
+    """n_grid < 2 is a degenerate integration grid and must raise, not silently
+    produce garbage."""
+    ple = dca.PLE(qi=1000.0, Di=0.5, Dinf=0.1, n=0.6)
+    t = dca.get_time(1.0, 5000.0, 60)
+    with pytest.raises(ValueError):
+        ple.cum(t, n_grid=n_grid)


### PR DESCRIPTION
Follow-up to #20 (SE gamma fix) and #21 (`n_grid`), landing changes that weren't part of either contributor PR.

## Hardening
- **`n_grid` guard** — `_integrate_with` now raises `ValueError` for `n_grid < 2` (a degenerate grid), validated before the empty-`t` early return.
- **Docstrings** — `n_grid` is documented on the public `cum()` and the sibling volume methods (`interval_vol`, `monthly_vol`, `monthly_vol_equiv`), which previously claimed kwargs were "currently unused, reserved for future use." `monthly_vol_equiv` now threads `**kwargs` through its `prepend` call, matching `interval_vol`.

## Tests
- Cover the `n_grid < 2` guard and the SE small-`n` gamma-overflow fallback path (the parametrized SE regression only exercised `n ∈ [0.3, 0.8]`, i.e. the closed-form branch).

## Error analysis
- `docs/numerical_integration.rst` + `integration_validation.py` gain an `n_grid` convergence characterization (second-order; 10,000 → ~2e-6, 2,000 → ~5e-5 worst-case relative error), a note on the SE small-`n` fallback, and a `print_ngrid_convergence()` helper so the table is reproducible. Accuracy is governed by `n_grid`, not the density of the requested `t` array.

## Coverage
- Upload coverage to Coveralls via `coverallsapp/github-action@v2` (ubuntu/3.12 cell). `pytest` now writes `coverage.lcov`. The upload step is `continue-on-error` because the `test` matrix is a required check on `main` — a Coveralls outage must not block merges. `coverage/coveralls` can be re-added as a required check once it reports.

## Version
- Bump `2.0.0` → `2.1.0`. The SE fix is flagged in the version history as a **breaking numerical change** (EUR/cum for any SE fit with `n ≠ 0.5` now differ — understated up to ~64% at `n=0.3`, overstated ~10% for `n > 0.5`).

Verified locally: `ruff` clean, `mypy` clean, 39 tests pass.
